### PR TITLE
Implement lazy dial udp

### DIFF
--- a/statsd.go
+++ b/statsd.go
@@ -1,6 +1,8 @@
 package statsd
 
-import "time"
+import (
+	"time"
+)
 
 // A Client represents a StatsD client.
 type Client struct {

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -384,7 +384,7 @@ type mockClosedUDPConn struct {
 	net.PacketConn
 }
 
-func (c *mockClosedUDPConn) Write(p []byte) (int, error) {
+func (c *mockClosedUDPConn) WriteTo(p []byte, addr net.Addr) (int, error) {
 	c.i++
 	if c.i == 2 {
 		return 0, errors.New("test error")


### PR DESCRIPTION
This will allow the statsd client to start without needing a conn to the metric service. Every write attempt will check whether or not it should attempt to reconnect to the service. 

If it is successful, the future writes will write to the stats service. If unsuccessful, it will essentially make the write a noop in regards to writing metrics to the server.